### PR TITLE
Give form is preceded by text, if it's included.

### DIFF
--- a/wp-content/themes/scripted/partials/donation-form.php
+++ b/wp-content/themes/scripted/partials/donation-form.php
@@ -6,7 +6,13 @@
 
     <div class="wrapper">
 
-      <div class="column col-8 push-2">
+      <? if ( $post->post_content != "" ) { ?>
+        <div class="column col-8 push-2 greedy">
+          <? the_content() ?>
+        </div>
+      <? } ?>
+
+      <div class="column col-8 push-2 greedy">
         <div id="give-messages"></div>
       </div>
 


### PR DESCRIPTION
Resolves #23 by allowing `the_content()` to be displayed.
