### PR TITLE
Single and archive event map is protocol-agnostic

### DIFF
--- a/wp-content/themes/scripted/embed/se_event.php
+++ b/wp-content/themes/scripted/embed/se_event.php
@@ -27,7 +27,7 @@
   <? if ( isset($event['location']['address']) ) { ?>
     <div class="map">
       <a href="http://maps.google.com/?q=<?= urlencode($event['location']['address']) ?>" target="_blank">
-        <img src="<?= 'http://maps.googleapis.com/maps/api/staticmap?center=' . urlencode($event['location']['address']). '&zoom=15&size=800x300&markers=label:1%7C' . ( $event['location']['lat'] . ',' . $event['location']['lng'] ) ?>" />
+        <img src="<?= '//maps.googleapis.com/maps/api/staticmap?center=' . urlencode($event['location']['address']). '&zoom=15&size=800x300&markers=label:1%7C' . ( $event['location']['lat'] . ',' . $event['location']['lng'] ) ?>" />
       </a>
     </div>
   <? } ?>

--- a/wp-content/themes/scripted/embed/single/se_event.php
+++ b/wp-content/themes/scripted/embed/single/se_event.php
@@ -80,7 +80,7 @@
       <? if ( $event['location']['address'] ) { ?>
         <div class="map">
           <a href="http://maps.google.com/?q=<?= urlencode($event['location']['address']) ?>" target="_blank">
-            <img src="<?= 'http://maps.googleapis.com/maps/api/staticmap?center=' . urlencode($event['location']['address']). '&zoom=13&size=800x300&markers=label:1%7C' . ( $event['location']['lat'] . ',' . $event['location']['lng'] ) ?>" />
+            <img src="<?= '//maps.googleapis.com/maps/api/staticmap?center=' . urlencode($event['location']['address']). '&zoom=13&size=800x300&markers=label:1%7C' . ( $event['location']['lat'] . ',' . $event['location']['lng'] ) ?>" />
           </a>
         </div>
       <? } ?>


### PR DESCRIPTION
Some pages complained that insecure content was being loaded.

Maps are now requested via the same protocol the page was loaded over, by starting the URL with `//`
